### PR TITLE
Dltp 1478 add edit groups to db

### DIFF
--- a/app/models/fedora_object.rb
+++ b/app/models/fedora_object.rb
@@ -1,6 +1,7 @@
 # A reporting record for an object persisted in Fedora.
 class FedoraObject < ActiveRecord::Base
   has_many :fedora_object_aggregation_keys, dependent: :destroy
+  has_many :fedora_object_edit_groups, dependent: :destroy
 
   def self.generic_files_by_mimetype(options = {})
     sql = " SELECT mimetype as type, sum(bytes) as total_bytes, count(pid) as pid_count

--- a/app/models/fedora_object_edit_group.rb
+++ b/app/models/fedora_object_edit_group.rb
@@ -1,0 +1,3 @@
+class FedoraObjectEditGroup < ActiveRecord::Base
+  belongs_to :fedora_object
+end

--- a/app/models/fedora_object_edit_group.rb
+++ b/app/models/fedora_object_edit_group.rb
@@ -1,3 +1,4 @@
+# Object for storing storing & reporting the group edit permissions on object
 class FedoraObjectEditGroup < ActiveRecord::Base
   belongs_to :fedora_object
 end

--- a/app/services/fedora_object_harvester.rb
+++ b/app/services/fedora_object_harvester.rb
@@ -116,6 +116,7 @@ class FedoraObjectHarvester
       predicate_names.each do |predicate_name|
         get_and_add_or_delete_aggregation_keys(fedora_object, predicate_name)
       end
+      get_and_add_or_delete_edit_groups(fedora_object)
     end
 
     # parse from triples: creator#administrative_unit
@@ -139,6 +140,35 @@ class FedoraObjectHarvester
       # destroy any prior aggregation keys which no longer exist
       fedora_object.fedora_object_aggregation_keys.where(predicate_name: predicate_name).each do |fedora_object_aggregation_key|
         fedora_object_aggregation_key.destroy unless agg_key_array.include? fedora_object_aggregation_key.aggregation_key
+      end
+    end
+
+    # parse edit_groups from rightsMetadata, and find group name for each edit_group
+    def get_and_add_or_delete_edit_groups(fedora_object)
+      # find each of the edit_groups
+      edit_groups_array = []
+      if doc.datastreams.key?('rightsMetadata')
+        edit_groups_array = parse_edit_groups(doc.datastreams['rightsMetadata'].content)
+      end
+      # load group name for each edit_group
+      edit_groups_list = load_group_names_for(edit_groups_array)
+      # add any new edit_groups which don't already exist
+      if edit_groups_list.any?
+        edit_groups_list.each do |edit_group|
+          group_pid = strip_pid(edit_group[:group_pid])
+          group_name = edit_group[:group_name]
+          FedoraObjectEditGroup.where(fedora_object: fedora_object, edit_group_pid: group_pid, edit_group_name: group_name).first_or_initialize(&:save)
+        end
+      end
+      # destroy any prior edit_groups which no longer exist
+      fedora_object.fedora_object_edit_groups.any? do
+        group_pid_array = []
+        edit_groups_array.each do |pid|
+          group_pid_array.push strip_pid(pid.to_s)
+        end
+        fedora_object.fedora_object_edit_groups.each do |edit_group|
+          edit_group.destroy unless group_pid_array.include? edit_group.edit_group_pid
+        end
       end
     end
 
@@ -225,6 +255,43 @@ class FedoraObjectHarvester
       parse_xml_relsext(doc.datastreams['RELS-EXT'].content, 'isPartOf')
     end
 
+    # @param pid_array [Array] an array of group_pid strings
+    # @return [Array] an array of hashes: {group_pid:, group_name:}
+    def load_group_names_for(pid_array)
+      group_elements = []
+      pid_array.each do |pid|
+        group_pid = pid.to_s
+        group_elements.push group_pid: group_pid, group_name: get_group_name_for_pid(group_pid)
+      end
+      group_elements
+    end
+
+    def get_group_name_for_pid(group_pid)
+      # get Fedora record for group
+      group_object = @repo.find(group_pid)
+      # parse descMetadata for group's name
+      return '' unless doc.datastreams.key?('descMetadata')
+      stream = group_object.datastreams['descMetadata'].content
+      parse_triples(stream, 'title').first || ''
+    end
+
+    ## ============================================================================
+    # create an array of edit grou pids from parsed xml doc
+    def parse_edit_groups(stream)
+      xml_doc = REXML::Document.new(stream)
+      root = xml_doc.root
+      edit_rights(root.elements["//access[@type='edit']"])
+    end
+
+    # <access type="edit"><human/><machine><person>abc</person><group>und:xxxxxx</group><group>und:xxxxxx</group></machine></access>
+    def edit_rights(this_access)
+      rights_array = []
+      this_access.elements['machine'].get_elements('group').each do |value|
+        rights_array.push value.text
+      end
+      rights_array
+    end
+
     ## ============================================================================
     # create the access rights string from parsed xml doc
     def parse_xml_rights(stream)
@@ -237,18 +304,14 @@ class FedoraObjectHarvester
     def read_rights(this_access)
       rights_array = []
 
-      machine_group_rights = this_access.elements['machine'].elements['group']
-      unless machine_group_rights.nil?
-        machine_group_rights.each do |value|
-          rights_array << value
-        end
+      machine_group_rights = this_access.elements['machine'].get_elements('group')
+      machine_group_rights.each do |value|
+        rights_array.push value.text
       end
 
-      machine_person_rights = this_access.elements['machine'].elements['person']
-      unless machine_person_rights.nil?
-        machine_person_rights.each do |value|
-          rights_array << value
-        end
+      machine_person_rights = this_access.elements['machine'].get_elements('person')
+      machine_person_rights.each do |value|
+        rights_array.push value.text
       end
 
       if rights_array.include? 'public'

--- a/app/services/fedora_object_harvester.rb
+++ b/app/services/fedora_object_harvester.rb
@@ -272,7 +272,7 @@ class FedoraObjectHarvester
       # parse descMetadata for group's name
       return '' unless doc.datastreams.key?('descMetadata')
       stream = group_object.datastreams['descMetadata'].content
-      parse_triples(stream, 'title').first || ''
+      parse_triples(stream, 'title').first || 'Group name not found'
     end
 
     ## ============================================================================

--- a/db/migrate/20180725184352_create_fedora_object_edit_groups.rb
+++ b/db/migrate/20180725184352_create_fedora_object_edit_groups.rb
@@ -1,0 +1,11 @@
+class CreateFedoraObjectEditGroups < ActiveRecord::Migration
+  def change
+    create_table :fedora_object_edit_groups do |t|
+      t.belongs_to :fedora_object, index: true, foreign_key: true, null: false
+      t.string :edit_group_pid, index: true, null: false
+      t.string :edit_group_name, index: true, null: false
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170227211456) do
+ActiveRecord::Schema.define(version: 20180725184352) do
 
   create_table "curate_storage_details", force: :cascade do |t|
     t.string   "storage_type", limit: 255, null: false
@@ -54,6 +54,18 @@ ActiveRecord::Schema.define(version: 20170227211456) do
   add_index "fedora_object_aggregation_keys", ["fedora_object_id"], name: "index_fedora_object_aggregation_keys_on_fedora_object_id", using: :btree
   add_index "fedora_object_aggregation_keys", ["predicate_name"], name: "index_fedora_object_aggregation_keys_on_predicate_name", using: :btree
 
+  create_table "fedora_object_edit_groups", force: :cascade do |t|
+    t.integer  "fedora_object_id", limit: 4,   null: false
+    t.string   "edit_group_pid",   limit: 255, null: false
+    t.string   "edit_group_name",  limit: 255, null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+  end
+
+  add_index "fedora_object_edit_groups", ["edit_group_name"], name: "index_fedora_object_edit_groups_on_edit_group_name", using: :btree
+  add_index "fedora_object_edit_groups", ["edit_group_pid"], name: "index_fedora_object_edit_groups_on_edit_group_pid", using: :btree
+  add_index "fedora_object_edit_groups", ["fedora_object_id"], name: "index_fedora_object_edit_groups_on_fedora_object_id", using: :btree
+
   create_table "fedora_objects", force: :cascade do |t|
     t.string   "pid",               limit: 255,              null: false
     t.string   "af_model",          limit: 255,              null: false
@@ -93,4 +105,5 @@ ActiveRecord::Schema.define(version: 20170227211456) do
   add_index "periodic_metric_reports", ["start_date"], name: "index_periodic_metric_reports_on_start_date", using: :btree
 
   add_foreign_key "fedora_object_aggregation_keys", "fedora_objects"
+  add_foreign_key "fedora_object_edit_groups", "fedora_objects"
 end

--- a/script/load_edit_groups.rb
+++ b/script/load_edit_groups.rb
@@ -1,0 +1,131 @@
+require 'rubydora'
+require 'rexml/document'
+require 'rdf/ntriples'
+require 'rdf/rdfxml'
+# Responsible for loading all FedoraObjectEditGroups based on FedoraObject
+#
+# This script should be run within the context of the Rails environment via the
+# `rails runner` command.
+#
+# ```console
+# $ cd <CURRENT_WORKING_DIRECTORY>
+# $ bundle exec rails runner -e <RAILS_ENV> <__FILE__>
+# ```
+module LoadEditGroups
+  module_function
+
+  def write_edit_groups_for_fedora_object
+    @exceptions = []
+      @repo = Rubydora.connect url: Figaro.env.fedora_url!, user: Figaro.env.fedora_user!, password: Figaro.env.fedora_password!
+      FedoraObject.find_each do |fedora_object|
+      begin
+        pid = "und:#{fedora_object.pid}"
+        logger.info "########### Get edit groups from Fedora for #{pid} ###############"
+        @doc = @repo.find pid
+        edit_groups_list = []
+        if @doc.datastreams.key?('rightsMetadata')
+          # find each of the edit_groups
+          edit_groups_array = parse_edit_groups(@doc.datastreams['rightsMetadata'].content)
+          # load group name for each edit_group
+          edit_groups_list = load_group_names_for(edit_groups_array)
+        end
+          # add any new edit_groups
+        if edit_groups_list.any?
+          edit_groups_list.each do |edit_group|
+            group_pid = strip_pid(edit_group[:group_pid])
+            group_name = edit_group[:group_name]
+            FedoraObjectEditGroup.where(fedora_object: fedora_object, edit_group_pid: group_pid, edit_group_name: group_name).first_or_initialize(&:save)
+          end
+        end
+        # destroy any prior edit_groups which no longer exist
+        fedora_object.fedora_object_edit_groups.any? do
+          group_pid_array = []
+          edit_groups_array.each do |pid|
+            group_pid_array.push strip_pid(pid.to_s)
+          end
+          fedora_object.fedora_object_edit_groups.each do |edit_group|
+            edit_group.destroy unless group_pid_array.include? edit_group.edit_group_pid
+          end
+        end
+      rescue Exception => e
+        logger.error "Error: error adding edit_groups for #{fedora_object.pid}.  Error was #{e}"
+        @exceptions << "Error: error loading edit groups for #{fedora_object.pid}.  Error: #{e}"
+      end
+    end
+    unless @exceptions.empty?
+      logger.error @exceptions.join(" ")
+    end
+  end
+## ============================================================================
+  def strip_pid(work_pid)
+    work_pid.sub('und:', '')
+  end
+
+  # @param pid_array [Array] an array of group_pid strings
+  # @return [Array] an array of hashes: {group_pid:, group_name:}
+  def load_group_names_for(pid_array)
+    group_elements = []
+    pid_array.each do |pid|
+      group_pid = pid.to_s
+      group_elements.push group_pid: group_pid, group_name: get_group_name_for_pid(group_pid)
+    end
+    group_elements
+  end
+
+  def get_group_name_for_pid(group_pid)
+    # get Fedora record for group
+    begin
+      group_object = @repo.find(group_pid)
+      # parse descMetadata for group's name
+      return '' unless @doc.datastreams.key?('descMetadata')
+      stream = group_object.datastreams['descMetadata'].content
+      parse_triples(stream, 'title').first || ''
+    rescue Exception => e
+      logger.error "Error: Error finding group object #{group_pid}. Error was #{e}"
+      return "Group does not exist"
+    end
+  end
+
+  ## ============================================================================
+  # create an array of edit grou pids from parsed xml doc
+  def parse_edit_groups(stream)
+    xml_doc = REXML::Document.new(stream)
+    root = xml_doc.root
+    edit_rights(root.elements["//access[@type='edit']"])
+  end
+
+  # <access type="edit"><human/><machine><person>abc</person><group>und:xxxxxx</group><group>und:xxxxxx</group></machine></access>
+  def edit_rights(this_access)
+    rights_array = []
+    this_access.elements['machine'].get_elements('group').each do |value|
+      rights_array.push value.text
+    end
+    rights_array
+  end
+
+  ## ============================================================================
+  # Parse triples format, returning an array of all values matching the search key.
+  def parse_triples(stream, search_key)
+    data_array = []
+    parse_uri = 'http://purl.org/dc/terms/'
+    full_uri = parse_uri + search_key
+    return data_array unless stream.include? full_uri
+    RDF::NTriples::Reader.new(stream) do |reader|
+      begin
+        reader.each_statement do |statement|
+          next unless statement.predicate.to_s == full_uri
+          data_array << statement.object.to_s
+        end
+      rescue RDF::ReaderError => e
+        logger.error "Error: error parsing for group name for #{@doc.pid}. Error was #{e}"
+      end
+    end
+    data_array.reject(&:empty?)
+  end
+end
+
+def logger
+  Rails.logger
+end
+
+LoadEditGroups.write_edit_groups_for_fedora_object

--- a/spec/fixtures/vcr_tests/test_cassette.yml
+++ b/spec/fixtures/vcr_tests/test_cassette.yml
@@ -8,7 +8,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -46,7 +46,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -89,7 +89,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -127,7 +127,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -174,7 +174,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -219,7 +219,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -266,7 +266,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -331,7 +331,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -369,7 +369,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -407,7 +407,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -450,7 +450,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -488,7 +488,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -534,7 +534,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -577,7 +577,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -624,7 +624,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -662,7 +662,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -706,7 +706,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -749,7 +749,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -787,7 +787,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -833,7 +833,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -876,7 +876,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -923,7 +923,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -961,7 +961,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -1005,7 +1005,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -1038,7 +1038,7 @@ http_interactions:
           </objectFields>
           </resultList>
         </result>
-    http_version:
+    http_version: 
   recorded_at: Thu, 23 Feb 2017 15:52:29 GMT
 - request:
     method: get
@@ -1048,7 +1048,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -1076,7 +1076,7 @@ http_interactions:
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.fedora.info/definitions/1/0/access/
         http://www.fedora.info/definitions/1/0/objectProfile.xsd" pid="und:zs25x636043"
         ><objLabel></objLabel><objOwnerId>fedoraAdmin</objOwnerId><objModels><model>info:fedora/afmodel:Dataset</model><model>info:fedora/fedora-system:FedoraObject-3.0</model></objModels><objCreateDate>2015-01-20T19:57:53.352Z</objCreateDate><objLastModDate>2016-09-27T18:50:26.091Z</objLastModDate><objDissIndexViewURL>https://something.com/objects/und%3Azs25x636043/methods/fedora-system%3A3/viewMethodIndex</objDissIndexViewURL><objItemIndexViewURL>https://something.com/objects/und%3Azs25x636043/methods/fedora-system%3A3/viewItemIndex</objItemIndexViewURL><objState>A</objState></objectProfile>
-    http_version:
+    http_version: 
   recorded_at: Thu, 23 Feb 2017 15:52:29 GMT
 - request:
     method: get
@@ -1086,7 +1086,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -1113,15 +1113,14 @@ http_interactions:
       string: <?xml version="1.0" encoding="UTF-8"?><objectDatastreams xmlns="http://www.fedora.info/definitions/1/0/access/"
         xmlns:apim="http://www.fedora.info/definitions/1/0/management/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.fedora.info/definitions/1/0/access/
-        https://something.com/schema/listDatastreams.xsd"
-        pid="und:zs25x636043"  baseURL="https://something.com/"
+        https://something.com/schema/listDatastreams.xsd" pid="und:zs25x636043"  baseURL="https://something.com/"
         ><datastreamProfile pid="und:zs25x636043" dsID="DC" ><apim:dsLabel>Dublin
         Core Record for this object</apim:dsLabel><apim:dsVersionID>DC1.0</apim:dsVersionID><apim:dsCreateDate>2015-01-20T19:57:53.352Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/xml</apim:dsMIME><apim:dsFormatURI>http://www.openarchives.org/OAI/2.0/oai_dc/</apim:dsFormatURI><apim:dsControlGroup>X</apim:dsControlGroup><apim:dsSize>344</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:zs25x636043+DC+DC1.0</apim:dsLocation><apim:dsLocationType></apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>97128e125d87c1f7de5d94b80ac6e22e</apim:dsChecksum></datastreamProfile><datastreamProfile
         pid="und:zs25x636043" dsID="RELS-EXT" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>RELS-EXT.12</apim:dsVersionID><apim:dsCreateDate>2016-09-27T18:50:21.380Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>application/rdf+xml</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>619</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:zs25x636043+RELS-EXT+RELS-EXT.12</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>7333b2426c36478a1b969dfef3879b24</apim:dsChecksum></datastreamProfile><datastreamProfile
         pid="und:zs25x636043" dsID="rightsMetadata" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>rightsMetadata.20</apim:dsVersionID><apim:dsCreateDate>2016-09-27T18:50:25.587Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/xml</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>633</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:zs25x636043+rightsMetadata+rightsMetadata.20</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>fcb03139c3af956e14e7d89b5cc14287</apim:dsChecksum></datastreamProfile><datastreamProfile
         pid="und:zs25x636043" dsID="descMetadata" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>descMetadata.20</apim:dsVersionID><apim:dsCreateDate>2016-09-27T18:50:26.091Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/plain</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>1186</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:zs25x636043+descMetadata+descMetadata.20</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>86027ca779af976000b209e54d092bf3</apim:dsChecksum></datastreamProfile><datastreamProfile
         pid="und:zs25x636043" dsID="properties" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>properties.6</apim:dsVersionID><apim:dsCreateDate>2016-09-27T18:50:10.738Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/xml</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>100</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:zs25x636043+properties+properties.6</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>c7107a90de5703effd5354fd68d301e3</apim:dsChecksum></datastreamProfile></objectDatastreams>
-    http_version:
+    http_version: 
   recorded_at: Thu, 23 Feb 2017 15:52:30 GMT
 - request:
     method: get
@@ -1131,7 +1130,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -1170,7 +1169,7 @@ http_interactions:
         <info:fedora/und:zs25x636043> <http://purl.org/dc/terms/spatial> "El Salvador" .
         <info:fedora/und:zs25x636043> <http://purl.org/dc/terms/rights> "All rights reserved" .
         <info:fedora/und:zs25x636043> <http://purl.org/dc/terms/modified> "2016-09-27Z"^^<http://www.w3.org/2001/XMLSchema#date> .
-    http_version:
+    http_version: 
   recorded_at: Thu, 23 Feb 2017 15:52:30 GMT
 - request:
     method: get
@@ -1180,7 +1179,7 @@ http_interactions:
       string: ''
     headers:
       Accept:
-      - '*/*; q=0.5, application/xml'
+      - "*/*; q=0.5, application/xml"
       Accept-Encoding:
       - gzip, deflate
       User-Agent:
@@ -1214,6 +1213,215 @@ http_interactions:
         \ </access>\n  <access type=\"edit\">\n    <human/>\n    <machine>\n      \n
         \     \n    <group>und:ms35t724s3j</group><person>ddressin</person></machine>\n
         \ </access>\n  <embargo>\n    <human/>\n    <machine/>\n  </embargo>\n</rightsMetadata>"
-    http_version:
+    http_version: 
   recorded_at: Thu, 23 Feb 2017 15:52:30 GMT
+- request:
+    method: get
+    uri: https://something.com/objects?pid=true&query=pid~und:ms35t724s3j&resultFormat=xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46M1dpYzR1WHk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=57581CC8BF64C08E44594DC0F7A2FEAB; Path=/fedora; Secure
+      Date:
+      - Fri, 27 Jul 2018 20:40:50 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '461'
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <result xmlns="http://www.fedora.info/definitions/1/0/types/" xmlns:types="http://www.fedora.info/definitions/1/0/types/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.fedora.info/definitions/1/0/types/ https://something.com/schema/findObjects.xsd">
+          <resultList>
+          <objectFields>
+              <pid>und:ms35t724s3j</pid>
+          </objectFields>
+          </resultList>
+        </result>
+    http_version: 
+  recorded_at: Fri, 27 Jul 2018 20:40:50 GMT
+- request:
+    method: get
+    uri: https://something.com/objects/und:ms35t724s3j?format=xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46M1dpYzR1WHk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=0CCCBAB4718E2473FD08092C19A3565C; Path=/fedora; Secure
+      Date:
+      - Fri, 27 Jul 2018 20:40:50 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '1004'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><objectProfile  xmlns="http://www.fedora.info/definitions/1/0/access/"  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.fedora.info/definitions/1/0/access/
+        http://www.fedora.info/definitions/1/0/objectProfile.xsd" pid="und:ms35t724s3j"
+        ><objLabel></objLabel><objOwnerId>fedoraAdmin</objOwnerId><objModels><model>info:fedora/afmodel:Hydramata_Group</model><model>info:fedora/fedora-system:FedoraObject-3.0</model></objModels><objCreateDate>2015-01-20T19:51:38.240Z</objCreateDate><objLastModDate>2018-05-11T14:12:55.518Z</objLastModDate><objDissIndexViewURL>https://something.com/objects/und%3Ams35t724s3j/methods/fedora-system%3A3/viewMethodIndex</objDissIndexViewURL><objItemIndexViewURL>https://something.com/objects/und%3Ams35t724s3j/methods/fedora-system%3A3/viewItemIndex</objItemIndexViewURL><objState>A</objState></objectProfile>
+    http_version: 
+  recorded_at: Fri, 27 Jul 2018 20:40:50 GMT
+- request:
+    method: get
+    uri: https://something.com/objects/und:ms35t724s3j/datastreams?format=xml&profiles=true
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46M1dpYzR1WHk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=2603D0C0BEE9818EB799537E16958392; Path=/fedora; Secure
+      Date:
+      - Fri, 27 Jul 2018 20:40:50 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '4210'
+    body:
+      encoding: UTF-8
+      string: <?xml version="1.0" encoding="UTF-8"?><objectDatastreams xmlns="http://www.fedora.info/definitions/1/0/access/"
+        xmlns:apim="http://www.fedora.info/definitions/1/0/management/" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.fedora.info/definitions/1/0/access/
+        https://something.com/schema/listDatastreams.xsd"
+        pid="und:ms35t724s3j"  baseURL="https://something.com/"
+        ><datastreamProfile pid="und:ms35t724s3j" dsID="DC" ><apim:dsLabel>Dublin
+        Core Record for this object</apim:dsLabel><apim:dsVersionID>DC1.0</apim:dsVersionID><apim:dsCreateDate>2015-01-20T19:51:38.240Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/xml</apim:dsMIME><apim:dsFormatURI>http://www.openarchives.org/OAI/2.0/oai_dc/</apim:dsFormatURI><apim:dsControlGroup>X</apim:dsControlGroup><apim:dsSize>344</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:ms35t724s3j+DC+DC1.0</apim:dsLocation><apim:dsLocationType></apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>b0e772434abdae5838cbc5a89b4d3567</apim:dsChecksum></datastreamProfile><datastreamProfile
+        pid="und:ms35t724s3j" dsID="RELS-EXT" ><apim:dsLabel>Fedora Object-to-Object
+        Relationship Metadata</apim:dsLabel><apim:dsVersionID>RELS-EXT.77</apim:dsVersionID><apim:dsCreateDate>2018-05-11T14:12:55.185Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>application/rdf+xml</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>X</apim:dsControlGroup><apim:dsSize>1220</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:ms35t724s3j+RELS-EXT+RELS-EXT.77</apim:dsLocation><apim:dsLocationType></apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>3afc5713a41a2f3d27784a43a782de94</apim:dsChecksum></datastreamProfile><datastreamProfile
+        pid="und:ms35t724s3j" dsID="rightsMetadata" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>rightsMetadata.16</apim:dsVersionID><apim:dsCreateDate>2018-05-11T14:12:55.518Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/xml</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>665</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:ms35t724s3j+rightsMetadata+rightsMetadata.16</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>597d6e212b3e4ac005c078da2c851c5f</apim:dsChecksum></datastreamProfile><datastreamProfile
+        pid="und:ms35t724s3j" dsID="properties" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>properties.0</apim:dsVersionID><apim:dsCreateDate>2015-01-20T19:51:39.010Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/xml</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>52</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:ms35t724s3j+properties+properties.0</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>16fc293ab673b2cb53065dc1052d575a</apim:dsChecksum></datastreamProfile><datastreamProfile
+        pid="und:ms35t724s3j" dsID="descMetadata" ><apim:dsLabel></apim:dsLabel><apim:dsVersionID>descMetadata.2</apim:dsVersionID><apim:dsCreateDate>2015-01-20T19:51:41.776Z</apim:dsCreateDate><apim:dsState>A</apim:dsState><apim:dsMIME>text/plain</apim:dsMIME><apim:dsFormatURI></apim:dsFormatURI><apim:dsControlGroup>M</apim:dsControlGroup><apim:dsSize>196</apim:dsSize><apim:dsVersionable>true</apim:dsVersionable><apim:dsInfoType></apim:dsInfoType><apim:dsLocation>und:ms35t724s3j+descMetadata+descMetadata.2</apim:dsLocation><apim:dsLocationType>INTERNAL_ID</apim:dsLocationType><apim:dsChecksumType>MD5</apim:dsChecksumType><apim:dsChecksum>8cd119152d6c945d763e5828555a1409</apim:dsChecksum></datastreamProfile></objectDatastreams>
+    http_version: 
+  recorded_at: Fri, 27 Jul 2018 20:40:50 GMT
+- request:
+    method: get
+    uri: https://something.com/objects/und:ms35t724s3j/datastreams/descMetadata/content
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46M1dpYzR1WHk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=EB5D78223C990DF0828F91799453073C; Path=/fedora; Secure
+      Content-Disposition:
+      - inline; filename="descMetadata.txt"
+      Date:
+      - Fri, 27 Jul 2018 20:40:50 GMT
+      Content-Type:
+      - text/plain
+      Content-Length:
+      - '196'
+    body:
+      encoding: UTF-8
+      string: |
+        <info:fedora/und:ms35t724s3j> <http://purl.org/dc/terms/title> "LAPOP GROUP" .
+        <info:fedora/und:ms35t724s3j> <http://purl.org/dc/terms/description> "Latin American Public Opinion Project Group" .
+    http_version: 
+  recorded_at: Fri, 27 Jul 2018 20:40:50 GMT
+- request:
+    method: get
+    uri: https://something.com/objects/und:ms35t724s3j/datastreams/rightsMetadata/content
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - "*/*; q=0.5, application/xml"
+      Accept-Encoding:
+      - gzip, deflate
+      User-Agent:
+      - Ruby
+      Authorization:
+      - Basic ZmVkb3JhQWRtaW46M1dpYzR1WHk=
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - Apache-Coyote/1.1
+      Set-Cookie:
+      - JSESSIONID=55C51DB8AA703D7C256CD7EC30FBC7C6; Path=/fedora; Secure
+      Content-Disposition:
+      - inline; filename="rightsMetadata.xml"
+      Date:
+      - Fri, 27 Jul 2018 20:40:50 GMT
+      Content-Type:
+      - text/xml
+      Content-Length:
+      - '665'
+    body:
+      encoding: UTF-8
+      string: "<rightsMetadata xmlns=\"http://hydra-collab.stanford.edu/schemas/rightsMetadata/v1\"
+        version=\"0.1\">\n  <copyright>\n    <human type=\"title\"/>\n    <human type=\"description\"/>\n
+        \   <machine type=\"uri\"/>\n  </copyright>\n  <access type=\"discover\">\n
+        \   <human/>\n    <machine/>\n  </access>\n  <access type=\"read\">\n    <human/>\n
+        \   <machine/>\n  </access>\n  <access type=\"edit\">\n    <human/>\n    <machine>\n
+        \     \n    <person>dbrower</person><person>jfriesen</person><person>msisk1</person><person>apapson</person><person>lajamie</person><person>mmoore18</person><person>cnietoma</person></machine>\n
+        \ </access>\n  <embargo>\n    <human/>\n    <machine/>\n  </embargo>\n</rightsMetadata>"
+    http_version: 
+  recorded_at: Fri, 27 Jul 2018 20:40:51 GMT
 recorded_with: VCR 3.0.1


### PR DESCRIPTION
https://jira.library.nd.edu/browse/DLTP-1478

Add new table fedora_object_edit_groups
Add methods to gather the information on the edit groups for each fedora object as it is harvested.
Rebuild VCR data for test data to cover new schema
Fix error with XML parsing that allowed only the first node to be found

Add script/load_edit_groups.rb to initialize data in FedoraObjectEditGroup table.