### PR TITLE
Fix Fedora Harvester bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,20 @@ Crontab is used as the scheduler to run, on a weekly basis, weekly_metrics_repor
 
 Looking at the `.travis.yml` file, use the `script` value (e.g. `bundle exec rake`). This
 script is what Travis runs when we push builds. If you do not have mysql running, and
-installed via homebrew, you may need to run `mysql.server start` to launch mysql
+installed via homebrew, you may need to run `mysql.server start` to launch mysql.
 
 ```console
 $ bundle exec rake
 ```
 
 # Usage
+
+To test fedora harvester locally:
+* `mysql.server start` to launch mysql
+* `bundle exec rake db:drop db:create db:schema:load` to initialize database
+* Use jetty (see ndlib/curate_nd) to set up localhost fedora, and copy objects from production fedora to localhost (see ndlib/f3cp). Update application.yml to point to fedora storage location if not using localhost. 
+* `bundle exec rake metrics:harvest_fedora` to output to database
+* check /log/development.log for logged errors
 
 To run locally:
 

--- a/app/services/fedora_object_harvester.rb
+++ b/app/services/fedora_object_harvester.rb
@@ -385,19 +385,18 @@ class FedoraObjectHarvester
       full_uri = parse_uri + search_key
       return data_array unless stream.include? full_uri
 
-      RDF::NTriples::Reader.new(stream) do |reader|
-        loop do
-          statement = reader.read_value
-          next unless statement.predicate.to_s == full_uri
+      stream_reader = RDF::NTriples::Reader.new(stream)
+      loop do
+        statement = stream_reader.read_value
+        next unless statement.predicate.to_s == full_uri
 
-          data_array << statement.object.to_s
-        rescue EOFError
-          break
-        rescue NoMethodError
-          next
-        rescue RDF::ReaderError => e
-          harvester.exceptions << FedoraObjectHarvesterError.new(pid, e)
-        end
+        data_array << statement.object.to_s
+      rescue EOFError
+        break
+      rescue NoMethodError
+        next
+      rescue RDF::ReaderError => e
+        harvester.exceptions << FedoraObjectHarvesterError.new(pid, e)
       end
       data_array.reject(&:empty?)
     end

--- a/config/application.yml
+++ b/config/application.yml
@@ -29,9 +29,9 @@ smtp_enable_starttls_auto: 'true'
 smtp_delivery_method: smtp
 
 development:
-  fedora_user: fedora
-  fedora_password: password
-  fedora_url: https://something.com
+  fedora_user: fedoraAdmin
+  fedora_password: fedoraAdmin
+  fedora_url: http://localhost:8983/fedora
   METRICS_REPORT_RECIPIENT: library@nd.edu
   METRICS_REPORT_SENDER: no-reply@nd.edu
  # sentry_dsn: 'put something here if you want it for testing and change  config.consider_all_requests_local = false'

--- a/config/database.yml
+++ b/config/database.yml
@@ -23,7 +23,7 @@ mysql_connection: &mysql_connection
 
 mysql_settings: &mysql_settings
   adapter:   mysql2
-  encoding:  utf8
+  encoding:  utf8mb4
   reconnect: false
   pool:      5
 


### PR DESCRIPTION
Handle error situations.
Document how to run harvester locally.

Fixes CURATE-339

Note: File FedoraObject needs to have the encoding altered on servers to solve an encoding issue with certain characters in titles:
`ALTER TABLE your_database_name.your_table CONVERT TO CHARACTER SET utf8mb4`
See https://stackoverflow.com/questions/22464011/mysql2error-incorrect-string-value for additional information.